### PR TITLE
Copy across clusterGeneric HPC wrapper scripts

### DIFF
--- a/recipes/bigdatascript/build.sh
+++ b/recipes/bigdatascript/build.sh
@@ -5,4 +5,8 @@ BDS_HOME="${PREFIX}/opt/bds" scripts/install.sh
 mkdir -p "${PREFIX}/bin"
 ln -s "${PREFIX}/opt/bds/bds" "${PREFIX}/bin/bds"
 ln -s "${PREFIX}/opt/bds/bds.config" "${PREFIX}/bin/bds.config"
+# Include 'clusterGeneric' HPC queue wrapper scripts not installed by default
+cp -r config "${PREFIX}/opt/bds/"
+# Update default bds.config to contain correct paths to 'clusterGeneric' wrapper scripts
+sed -i 's/\~\/\.bds/'${PREFIX}'\/opt\/bds\/config/' "${PREFIX}/opt/bds/bds.config"
 chmod 0755 "${PREFIX}/opt/bds/bds"


### PR DESCRIPTION
The BDS install script doesn't copy across the 'clusterGeneric' wrapper scripts, but it's nice to have these as part of the Conda package (otherwise in an automated installation on HPC we need to also pull the Git repo just to get those scripts).

Changes are untested - the path in the sed substitution could be wrong - I think we actually want a path with a version included like `${PREFIX}/opt/bds-${PKG_BUILD_STRING}` - or maybe there is a better [Conda build environment variable](https://conda.io/docs/user-guide/tasks/build-packages/environment-variables.html#environment-variables-set-during-the-build-process) that gives this ?